### PR TITLE
Allow different graphql server in cloud and local dev

### DIFF
--- a/.dev.vars
+++ b/.dev.vars
@@ -1,2 +1,3 @@
 OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4318/v1/traces"
 OTEL_EXPORTER_PAT = "foobar"
+GRAPHQL_SERVER_URL = "http://localhost:3280/graphql"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This plugin for Hasura DDN (Distributed Data Network) allows you to add RESTifie
 
 Configure the plugin in `src/config.ts`:
 
-- `graphqlServer`: GraphQL server settings (URL, headers)
+- `graphqlServer`: GraphQL server settings (headers)
 - `headers`: Authentication headers
 - `restifiedEndpoints`: Array of RESTified endpoint configurations
 
@@ -34,7 +34,6 @@ Example configuration:
 ```typescript
 export const Config = {
   graphqlServer: {
-    url: "http://localhost:3000/graphql",
     headers: {
       additional: {
         "Content-Type": "application/json",
@@ -47,7 +46,7 @@ export const Config = {
   },
   restifiedEndpoints: [
     {
-      path: "/v1/restified/:offset",
+      path: "/v1/api/rest/albums/:offset",
       methods: ["GET"],
       query: `
         query MyQuery($limit: Int = 10, $offset: Int = 10) {
@@ -60,6 +59,13 @@ export const Config = {
     // Add more RESTified endpoints here
   ],
 };
+```
+
+Configure the graphql server URL in `wrangler.toml` (or `.dev.vars`):
+
+```toml
+[vars]
+GRAPHQL_SERVER_URL = "<GRAPHQL_SERVER_URL>"
 ```
 
 ## Development
@@ -161,7 +167,7 @@ To add new RESTified endpoints, update the `restifiedEndpoints` array in `src/co
 ```typescript
 restifiedEndpoints: [
   {
-    path: "/v1/rest/users/:id",
+    path: "/v1/api/rest/users/:id",
     methods: ["GET"],
     query: `
       query GetUser($id: ID!) {
@@ -174,7 +180,7 @@ restifiedEndpoints: [
     `,
   },
   {
-    path: "/v1/rest/posts",
+    path: "/v1/api/rest/posts",
     method: ["POST"],
     query: `
       mutation CreatePost($title: String!, $content: String!) {

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export const Config = {
 };
 ```
 
-Configure the graphql server URL in `wrangler.toml` (or `.dev.vars`):
+Configure the graphql server URL in `.dev.vars`:
 
 ```toml
 [vars]
@@ -157,6 +157,8 @@ Build DDN supergraph:
 ```sh
 ddn supergraph build create
 ```
+
+Please update the GRAPHQL_SERVER_URL variable in the `wrangler.toml` with the projects graphql endpoint.
 
 **Note**: For end-to-end tracing, you would have to update the `wrangler.toml` file to add the Hasura PAT in `OTEL_EXPORTER_PAT` var.
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Build DDN supergraph:
 ddn supergraph build create
 ```
 
-Please update the GRAPHQL_SERVER_URL variable in the `wrangler.toml` with the projects graphql endpoint.
+Please update the GRAPHQL_SERVER_URL variable in the `wrangler.toml` with the project's graphql endpoint.
 
 **Note**: For end-to-end tracing, you would have to update the `wrangler.toml` file to add the Hasura PAT in `OTEL_EXPORTER_PAT` var.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This plugin for Hasura DDN (Distributed Data Network) allows you to add RESTifie
 - Transform GraphQL queries into REST-like endpoints
 - Configurable endpoint mapping
 - Authentication support
-- Variable extraction from URL parameters, query strings, and request bodies
+- Variable extraction from URL parameters, query strings, and request body
 - OpenTelemetry integration for tracing
 
 ## How it works
@@ -48,7 +48,7 @@ export const Config = {
   restifiedEndpoints: [
     {
       path: "/v1/restified/:offset",
-      method: "GET",
+      methods: ["GET"],
       query: `
         query MyQuery($limit: Int = 10, $offset: Int = 10) {
           Album(limit: $limit, offset: $offset) {
@@ -162,7 +162,7 @@ To add new RESTified endpoints, update the `restifiedEndpoints` array in `src/co
 restifiedEndpoints: [
   {
     path: "/v1/rest/users/:id",
-    method: "GET",
+    methods: ["GET"],
     query: `
       query GetUser($id: ID!) {
         user(id: $id) {
@@ -175,7 +175,7 @@ restifiedEndpoints: [
   },
   {
     path: "/v1/rest/posts",
-    method: "GET",
+    method: ["POST"],
     query: `
       mutation CreatePost($title: String!, $content: String!) {
         createPost(input: { title: $title, content: $content }) {
@@ -192,7 +192,6 @@ After adding new endpoints, redeploy the plugin for the changes to take effect.
 
 ## Limitations and Future Improvements
 
-- The plugin currently supports only GET methods. Support for other HTTP methods will be added in the future.
 - Currently, the plugin supports basic variable extraction. More complex scenarios might require additional implementation.
 - OpenAPI Spec documentation generation is not yet implemented.
 - Rate limiting is not currently supported within the plugin.

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ export const Config = {
       additional: {
         "Content-Type": "application/json",
       },
-      forward: ["X-Hasura-Role"],
+      forward: ["X-Hasura-Role", "Authorization", "X-Hasura-ddn-token"],
     },
   },
   headers: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,5 @@
 export const Config = {
   graphqlServer: {
-    url: "http://localhost:3000/graphql",
     headers: {
       additional: {
         "Content-Type": "application/json",
@@ -13,7 +12,7 @@ export const Config = {
   },
   restifiedEndpoints: [
     {
-      path: "/v1/restified/:offset",
+      path: "/v1/api/rest/albums/:offset",
       methods: ["GET", "POST"],
       query: `
         query MyQuery($limit: Int = 10, $offset: Int = 10) {

--- a/src/restified.ts
+++ b/src/restified.ts
@@ -12,7 +12,7 @@ interface RawRequest {
   body: JSON | null;
 }
 
-export const restifiedHandler = (request) => {
+export const restifiedHandler = (request, graphqlServerUrl: string) => {
   return tracer.startActiveSpan("Handle request", async (span) => {
     // Authentication
     if (
@@ -58,7 +58,7 @@ export const restifiedHandler = (request) => {
 
     // Execute GraphQL query
     try {
-      const result = await executeGraphQL(endpoint.query, variables, request);
+      const result = await executeGraphQL(endpoint.query, variables, request, graphqlServerUrl);
       span.setStatus({
         code: SpanStatusCode.OK,
         message: String("Query executed successfully"),
@@ -128,8 +128,8 @@ function extractVariables(request: RawRequest, endpoint) {
   return variables;
 }
 
-async function executeGraphQL(query, variables, request) {
-  const response = await fetch(Config.graphqlServer.url, {
+async function executeGraphQL(query, variables, request, graphqlServerUrl: string) {
+  const response = await fetch(graphqlServerUrl, {
     method: "POST",
     headers: {
       ...Config.graphqlServer.headers.forward.reduce((acc, header) => {

--- a/src/restified.ts
+++ b/src/restified.ts
@@ -58,7 +58,12 @@ export const restifiedHandler = (request, graphqlServerUrl: string) => {
 
     // Execute GraphQL query
     try {
-      const result = await executeGraphQL(endpoint.query, variables, request, graphqlServerUrl);
+      const result = await executeGraphQL(
+        endpoint.query,
+        variables,
+        request,
+        graphqlServerUrl,
+      );
       span.setStatus({
         code: SpanStatusCode.OK,
         message: String("Query executed successfully"),
@@ -128,7 +133,12 @@ function extractVariables(request: RawRequest, endpoint) {
   return variables;
 }
 
-async function executeGraphQL(query, variables, request, graphqlServerUrl: string) {
+async function executeGraphQL(
+  query,
+  variables,
+  request,
+  graphqlServerUrl: string,
+) {
   const response = await fetch(graphqlServerUrl, {
     method: "POST",
     headers: {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -15,7 +15,8 @@ import { instrument, ResolveConfigFn } from "@microlabs/otel-cf-workers";
 const handler = {
   async fetch(request, env, ctx) {
     trace.getActiveSpan()?.setAttribute("internal.visibility", String("user"));
-    return restifiedHandler(request);
+    const graphqlServerUrl = env.GRAPHQL_SERVER_URL;
+    return restifiedHandler(request, graphqlServerUrl);
   },
 };
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,3 +7,4 @@ compatibility_flags = [ "nodejs_compat" ]
 [vars]
 OTEL_EXPORTER_OTLP_ENDPOINT = "https://gateway.otlp.hasura.io:443/v1/traces"
 OTEL_EXPORTER_PAT = "<PAT>"
+GRAPHQL_SERVER_URL = "<GRAPHQL_SERVER_URL>"


### PR DESCRIPTION
This PR will allow us to have two different URLs for the graphql endpoint for local and cloud development.